### PR TITLE
Aktualizacja danych przechowywanych w Datastore

### DIFF
--- a/specs/api.md
+++ b/specs/api.md
@@ -190,6 +190,10 @@ Serwer zapisuje dane do tabeli `Encounters` wraz z odpowiednim `user_id`.
 
 `date` : `datatime`
 
+`processed_by_gis` : `bool`
+
+`confirmed_by_gis` : `bool`
+
 ## GCP BigQuery
 
 ### `Beacons`

--- a/specs/api.md
+++ b/specs/api.md
@@ -190,9 +190,9 @@ Serwer zapisuje dane do tabeli `Encounters` wraz z odpowiednim `user_id`.
 
 `date` : `datatime`
 
-`processed_by_gis` : `bool`
+`processed_by_health_authority` : `bool`
 
-`confirmed_by_gis` : `bool`
+`confirmed_by_health_authority` : `bool`
 
 ## GCP BigQuery
 


### PR DESCRIPTION
Dodanie pól wskazujących na przetworzenie i potwierdzenie chorego przez [GIS](https://gis.gov.pl) w nawiązaniu do https://github.com/ProteGO-app/backend/pull/34 